### PR TITLE
Adding the Sample column to the Portal Ingest form. 

### DIFF
--- a/barcode_quantification.py
+++ b/barcode_quantification.py
@@ -134,6 +134,7 @@ def run(fastq_directory, mapping_file, output_directory):
             results[barcode].append(barcode_hits[barcode])
             if barcode != 'Dummy' and barcode in barcode_to_pgl0:
                 dat = {
+                    "Sample":row['Sample'],
                     "Strain":row['Strain'],
                     "ORI (pGL0)": barcode_to_pgl0[barcode],
                     "Plasmid (pGL2)": barcode_to_pgl2[barcode],


### PR DESCRIPTION
Hi @kmendler 

This pull request just adds 1 line but I wanted to make sure it didn't disrupt your pipeline.

I add the "Sample" column to portal_ingest.tsv. So this way we can link that data to each sample's specific name.
```
Sample  Strain  ORI (pGL0)      Plasmid (pGL2)  Fold enrichment Cutoff
Blich_GEN_025X  CVM022  pGL0_115 [pBC1 ORI]     pGL2_138_pBC1   0.17    5.0
Blich_GEN_025X  CVM022  pGL0_22 [pSG5 ORI]      pGL2_138_pSG5   0.16    5.0
Blich_GEN_025X  CVM022  pGL0_11 [pWKS1 ORI]     pGL2_138_pWKS1  0.24    5.0
Blich_GEN_025X  CVM022  pGL0_153 [pCB102 ORI]   pGL2_138_pCB102 0.0     5.0
```
This may or may not be an issue for ingest - mainly I just need this change for my own interpretation of sample results. I suspect we might have to rework ingest to work off the sample name, though.