### PR TITLE
Get the cutoffs for each library::ORI combination

### DIFF
--- a/barcode_quantification.py
+++ b/barcode_quantification.py
@@ -252,7 +252,7 @@ def run(fastq_directory, mapping_file, library_info, output_directory, unmerged_
                     "Fold enrichment": round(
                         barcode_hits[barcode] / (1 + barcode_hits["Dummy"]), 2
                     ),
-                    "Cutoff": lib_ori_to_cutoff[row["Library"]][barcode],
+                    "Cutoff": lib_ori_to_cutoff.get(row["Library"], {}).get(barcode, None),
                 }
                 portal_ingest.append(dat)
 

--- a/barcode_quantification.py
+++ b/barcode_quantification.py
@@ -98,19 +98,17 @@ def run(fastq_directory, mapping_file, library_info, output_directory, unmerged_
     samples = pd.read_csv(mapping_file)
     libraries = list(samples.Library.unique())
     barcodes = set()
-    lib_to_cutoff = {}  # The cutoff value for each library
+    lib_ori_to_cutoff = defaultdict(dict[str, float])  # The cutoff value for each library & ORI combination
 
     for library in libraries:
         print("Making Database for {}".format(library))
 
         f = open("{}.fasta".format(library), "w+")
         lib_info = all_lib_info[all_lib_info.Library == library]
-        lib_to_cutoff[library] = lib_info["Negative control cutoff"].to_list()[
-            0
-        ]  # Should all be the same, take first
 
-        for index, row in lib_info.iterrows():
+        for _, row in lib_info.iterrows():            
             barcode = row["ORI"]
+            lib_ori_to_cutoff[library][barcode] = row["Negative control cutoff"]
             f.write(">" + barcode + "\n")
             f.write(row["ORI-barcode sequence"] + "\n")
             barcodes.add(barcode)
@@ -120,7 +118,7 @@ def run(fastq_directory, mapping_file, library_info, output_directory, unmerged_
     portal_ingest = []  # Form the final table for portal ingest
     stats = []  # Form the stats table
 
-    for index, row in samples.iterrows():
+    for _, row in samples.iterrows():
         filename = row["FileName"]
         print(filename)
         fn1 = glob.glob(fastq_directory + "/" + filename + "*_R1_*.fastq.gz")
@@ -254,7 +252,7 @@ def run(fastq_directory, mapping_file, library_info, output_directory, unmerged_
                     "Fold enrichment": round(
                         barcode_hits[barcode] / (1 + barcode_hits["Dummy"]), 2
                     ),
-                    "Cutoff": lib_to_cutoff[row["Library"]],
+                    "Cutoff": lib_ori_to_cutoff[row["Library"]][barcode],
                 }
                 portal_ingest.append(dat)
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Modify `run()` in `barcode_quantification.py` to handle cutoffs per library and ORI combination using `lib_ori_to_cutoff`.
> 
>   - **Behavior**:
>     - Modify `run()` in `barcode_quantification.py` to use `lib_ori_to_cutoff` for storing cutoff values per library and ORI combination instead of a single cutoff per library.
>     - Update `portal_ingest` data structure to use `lib_ori_to_cutoff` for the "Cutoff" field.
>   - **Code Quality**:
>     - Replace `for index, row in ...` with `for _, row in ...` in `run()` to ignore the index in loops.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cultivarium%2FORI-marker-screen&utm_source=github&utm_medium=referral)<sup> for 038c2b55c0277aaf852579c50e89aa7b2245c339. You can [customize](https://app.ellipsis.dev/cultivarium/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->